### PR TITLE
Replace Memcached implementation with PSR-6 compliant cache adapter

### DIFF
--- a/classes/ZipcodeChecker/Handlers/ZipcodeHandler.php
+++ b/classes/ZipcodeChecker/Handlers/ZipcodeHandler.php
@@ -2,6 +2,7 @@
 
 namespace Stplus\ZipcodeChecker\Handlers;
 
+use Cache\Adapter\Common\AbstractCachePool;
 use Stplus\ZipcodeChecker\Address;
 
 abstract class ZipcodeHandler implements ZipcodeHandlerInterface
@@ -12,7 +13,11 @@ abstract class ZipcodeHandler implements ZipcodeHandlerInterface
      * @var Address
      */
     protected $address;
-    protected $memcacheD;
+
+    /**
+     * @var AbstractCachePool
+     */
+    protected $cachePool;
 
     public function setNextHandler(ZipcodeHandlerInterface $nextHandler)
     {
@@ -20,9 +25,9 @@ abstract class ZipcodeHandler implements ZipcodeHandlerInterface
 
     }
 
-    public function handle(Address $address, \Memcached $memcacheD): Address
+    public function handle(Address $address, AbstractCachePool $cachePool): Address
     {
-        $this->memcacheD = $memcacheD;
+        $this->cachePool = $cachePool;
 
         echo get_class($this) . ' : ' . $address->getZipcode() . " => ";
 
@@ -33,7 +38,7 @@ abstract class ZipcodeHandler implements ZipcodeHandlerInterface
             return $this->address;
         } elseif ($this->nextHandler) {
             echo "Computer says no...<br/>";
-            $this->nextHandler->handle($address, $memcacheD);
+            $this->nextHandler->handle($address, $cachePool);
         }
 
         return $this->address;
@@ -48,8 +53,8 @@ abstract class ZipcodeHandler implements ZipcodeHandlerInterface
     private function writeAdressToCache()
     {
         if (null != $this->address->getStreet()) {
-            $this->memcacheD->set(ZipcodeHandlerCache::getCacheKey($this->address), serialize($this->address));
-            var_dump($this->memcacheD->get(ZipcodeHandlerCache::getCacheKey($this->address)));
+            $this->cachePool->set(ZipcodeHandlerCache::getCacheKey($this->address), serialize($this->address));
+            var_dump($this->cachePool->get(ZipcodeHandlerCache::getCacheKey($this->address)));
         }
     }
 

--- a/classes/ZipcodeChecker/Handlers/ZipcodeHandlerCache.php
+++ b/classes/ZipcodeChecker/Handlers/ZipcodeHandlerCache.php
@@ -21,7 +21,7 @@ class ZipcodeHandlerCache extends ZipcodeHandler
 
     protected function fetchAdress(): bool
     {
-        $cached = $this->memcacheD->get(self::getCacheKey($this->address));
+        $cached = $this->cachePool->get(self::getCacheKey($this->address));
         if ($cached) {
             $this->fillAdress($cached);
             return true;

--- a/classes/ZipcodeChecker/Handlers/ZipcodeHandlerInterface.php
+++ b/classes/ZipcodeChecker/Handlers/ZipcodeHandlerInterface.php
@@ -8,11 +8,12 @@
 
 namespace Stplus\ZipcodeChecker\Handlers;
 
+use Cache\Adapter\Common\AbstractCachePool;
 use  Stplus\ZipcodeChecker\Address;
 
 interface ZipcodeHandlerInterface
 {
     public function setNextHandler(ZipcodeHandlerInterface $nextHandler);
 
-    public function handle(Address $address, \Memcached $memcacheD): Address;
+    public function handle(Address $address, AbstractCachePool $memcacheD): Address;
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,8 @@
     "require": {
         "willdurand/geocoder": "^3.3",
         "php-http/guzzle6-adapter": "^1.1",
-        "freshheads/postcode-api-client": "^3.0"
+        "freshheads/postcode-api-client": "^3.0",
+        "cache/memcached-adapter": "^0.4.0"
     },
     "autoload": {
         "psr-4": {

--- a/index.php
+++ b/index.php
@@ -8,6 +8,7 @@ require __DIR__ . '/vendor/autoload.php';
 
 $memcacheD = new \Memcached();
 $memcacheD->addServer('127.0.0.1', 11211);
+$cachePool = new MemcachedCachePool($memcacheD);
 
 $chain = [];
 $chain[] = new Handlers\ZipcodeHandlerCache();
@@ -25,7 +26,7 @@ foreach($chain as $key=>$handler){
 $addressInput = new Address('9000','3068HL','Nederland');
 
 // start thechain
-$chain[0]->handle($addressInput, $memcacheD);
+$chain[0]->handle($addressInput, $cachePool);
 
 var_dump($addressInput);
 


### PR DESCRIPTION
This PR replaces the expectation of a Memcached instance with a PSR-6 compliant cache adapter. This allows you to replace the caching client just by using another cache adapter. 

See http://www.php-cache.com/en/latest/ for more information.